### PR TITLE
Upgrade dependencies (Manifest only)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ pnet_macros = "0.21.0"
 
 [dependencies]
 csv = "1"
-pcap = "0.5.7"
+pcap = "0.7"
 pnet = "0.21.0"
 pnet_macros = "0.21.0"
 pnet_macros_support = "0.21.0"
-serde = "0.9.11"
-serde_json = "0.9.9"
+serde = "1.0"
+serde_json = "1.0"
 time = "0.1"


### PR DESCRIPTION
The versions specified in your Cargo.toml are not the most recent versions of pcap, serde, or serde_json.

In serde's case, this is the cause of the mismatch causing csv to not work, as it builds against serde@1.0, and you're using serde@0.9's traits. These are distinct to the compiler, and produce unfortunate error messages due to the version mismatch.

This only changes the manifest, and does not touch actual code. Feel free to reject the PR if you can't or don't want to upgrade pcap at this time, I just bundled it in while checking all of the dependencies.

Serde, though, should be upgraded to 1.0 ASAP so you can use the whole ecosystem.